### PR TITLE
Update 02_segmentation_and_measuring.md fix error in first big cell

### DIFF
--- a/tutorial/02_segmentation_and_measuring.md
+++ b/tutorial/02_segmentation_and_measuring.md
@@ -39,7 +39,9 @@ Computationally, segmentations are most often represented as images, of the same
 Here is a very simple image and segmentation, taken from [this scikit-image gallery example](https://scikit-image.org/docs/dev/auto_examples/segmentation/plot_watershed.html#sphx-glr-auto-examples-segmentation-plot-watershed-py):
 
 ```{code-cell} ipython3
+import matplotlib.pyplot as plt
 import numpy as np
+
 from scipy import ndimage as ndi
 
 import napari


### PR DESCRIPTION
In the rendered website
https://scipy-2024-image-analysis.github.io/tutorial/02_segmentation_and_measuring.html#separating-an-image-into-one-or-more-regions-of-interest
there is an error:
<img width="807" alt="image" src="https://github.com/scipy-2024-image-analysis/tutorial/assets/76622105/04f0bc4a-fd17-4ee1-8a1c-5a8d5ee92b48">
